### PR TITLE
Update Mongoose version to match move to MongoDB 7

### DIFF
--- a/Develop/server/package.json
+++ b/Develop/server/package.json
@@ -14,7 +14,7 @@
     "bcrypt": "^4.0.1",
     "express": "^4.17.1",
     "jsonwebtoken": "^8.5.1",
-    "mongoose": "^7.0.2"
+    "mongoose": "^8.0.0"
   },
   "devDependencies": {
     "nodemon": "^2.0.3"


### PR DESCRIPTION
This PR updates the Mongoose version to match the move to MongoDB 7